### PR TITLE
アクティビティのライフサイクルを可視化

### DIFF
--- a/app/src/main/java/com/example/kouki/fujisue/androidlab/MainActivity.kt
+++ b/app/src/main/java/com/example/kouki/fujisue/androidlab/MainActivity.kt
@@ -21,6 +21,7 @@ import com.example.kouki.fujisue.androidlab.ui.dialog.DialogScreen
 import com.example.kouki.fujisue.androidlab.ui.image.ImageScreen
 import com.example.kouki.fujisue.androidlab.ui.input.InputScreen
 import com.example.kouki.fujisue.androidlab.ui.layout.LayoutsScreen
+import com.example.kouki.fujisue.androidlab.ui.lifecycle.LifecycleScreen
 import com.example.kouki.fujisue.androidlab.ui.list.ListScreen
 import com.example.kouki.fujisue.androidlab.ui.location.LocationScreen
 import com.example.kouki.fujisue.androidlab.ui.main.MainScreen
@@ -125,6 +126,9 @@ fun AppContent() {
             }
             composable<Route.LocationScreen> {
                 LocationScreen()
+            }
+            composable<Route.LifecycleScreen> {
+                LifecycleScreen()
             }
         }
     }

--- a/app/src/main/java/com/example/kouki/fujisue/androidlab/ui/lifecycle/LifecycleScreen.kt
+++ b/app/src/main/java/com/example/kouki/fujisue/androidlab/ui/lifecycle/LifecycleScreen.kt
@@ -26,8 +26,10 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.unit.dp
+import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.viewmodel.compose.viewModel
 import kotlinx.coroutines.launch
@@ -48,7 +50,6 @@ fun LifecycleScreen(
     // DisposableEffectを使ってライフサイクルイベントを監視します
     DisposableEffect(lifecycleOwner) {
         val observer = LifecycleEventObserver { _, event ->
-            // 状態を直接更新する代わりに、ViewModelのメソッドを呼び出す
             viewModel.addEvent(event)
         }
 
@@ -71,7 +72,7 @@ fun LifecycleScreen(
     Scaffold(
         topBar = {
             TopAppBar(
-                title = { Text("Lifecycle Observer with ViewModel") }, // タイトルを更新
+                title = { Text("Lifecycle Observer with ViewModel") },
                 colors = TopAppBarDefaults.topAppBarColors(
                     containerColor = MaterialTheme.colorScheme.primaryContainer,
                     titleContentColor = MaterialTheme.colorScheme.primary,
@@ -119,9 +120,21 @@ fun LifecycleScreen(
                 state = listState,
                 modifier = Modifier.fillMaxSize()
             ) {
-                items(lifecycleEvents) { event ->
+                items(lifecycleEvents) { log ->
+                    val color = when (log.event) {
+                        Lifecycle.Event.ON_CREATE,
+                        Lifecycle.Event.ON_START,
+                        Lifecycle.Event.ON_RESUME -> Color.Blue
+
+                        Lifecycle.Event.ON_PAUSE,
+                        Lifecycle.Event.ON_STOP -> Color.Gray
+
+                        Lifecycle.Event.ON_DESTROY -> Color.Red
+                        else -> MaterialTheme.colorScheme.onSurface
+                    }
                     Text(
-                        text = event,
+                        text = "${log.timestamp}: ${log.event.name}",
+                        color = color,
                         fontFamily = FontFamily.Monospace,
                         modifier = Modifier.padding(vertical = 4.dp)
                     )

--- a/app/src/main/java/com/example/kouki/fujisue/androidlab/ui/lifecycle/LifecycleScreen.kt
+++ b/app/src/main/java/com/example/kouki/fujisue/androidlab/ui/lifecycle/LifecycleScreen.kt
@@ -1,0 +1,134 @@
+package com.example.kouki.fujisue.androidlab.ui.lifecycle
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.LifecycleEventObserver
+import kotlinx.coroutines.launch
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun LifecycleScreen() {
+    val lifecycleOwner = androidx.lifecycle.compose.LocalLifecycleOwner.current
+    var lifecycleEvents by remember { mutableStateOf(listOf<String>()) }
+    val listState = rememberLazyListState()
+    val coroutineScope = rememberCoroutineScope()
+
+    // DisposableEffectを使ってライフサイクルイベントを監視します
+    DisposableEffect(lifecycleOwner) {
+        val observer = LifecycleEventObserver { _, event ->
+            val timestamp = SimpleDateFormat("HH:mm:ss.SSS", Locale.US).format(Date())
+            val newEvent = "$timestamp: ${event.name}"
+            lifecycleEvents = lifecycleEvents + newEvent
+        }
+
+        // オブザーバー（監視者）をライフサイクルに追加
+        lifecycleOwner.lifecycle.addObserver(observer)
+
+        // コンポーザブルが破棄されるときにオブザーバーを削除（クリーンアップ）
+        onDispose {
+            lifecycleOwner.lifecycle.removeObserver(observer)
+        }
+    }
+
+    // 新しいイベントが追加されたときにリストの最下部に自動スクロールします
+    LaunchedEffect(lifecycleEvents.size) {
+        if (lifecycleEvents.isNotEmpty()) {
+            coroutineScope.launch {
+                listState.animateScrollToItem(lifecycleEvents.size - 1)
+            }
+        }
+    }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("Lifecycle Observer") },
+                colors = TopAppBarDefaults.topAppBarColors(
+                    containerColor = MaterialTheme.colorScheme.primaryContainer,
+                    titleContentColor = MaterialTheme.colorScheme.primary,
+                )
+            )
+        }
+    ) { paddingValues ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(paddingValues)
+                .padding(16.dp),
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            Card(
+                modifier = Modifier.fillMaxWidth(),
+                colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceVariant)
+            ) {
+                Column(modifier = Modifier.padding(16.dp)) {
+                    Text(
+                        "この画面のライフサイクルイベントを監視しています。",
+                        style = MaterialTheme.typography.titleMedium
+                    )
+                    Spacer(modifier = Modifier.height(8.dp))
+                    Text(
+                        "以下の操作を試して、ログに記録されるイベントを確認してみましょう。",
+                        style = MaterialTheme.typography.bodyMedium
+                    )
+                    Spacer(modifier = Modifier.height(8.dp))
+                    Text(
+                        "• ホームボタンを押して、再度アプリを開く\n" +
+                                "• 他の画面に移動して、この画面に戻る\n" +
+                                "• 端末を回転させる",
+                        style = MaterialTheme.typography.bodySmall
+                    )
+                }
+            }
+
+            Spacer(modifier = Modifier.height(16.dp))
+
+            Text("Lifecycle Event Log", style = MaterialTheme.typography.titleMedium)
+            HorizontalDivider(modifier = Modifier.padding(vertical = 8.dp))
+
+            LazyColumn(
+                state = listState,
+                modifier = Modifier.fillMaxSize()
+            ) {
+                items(lifecycleEvents) { event ->
+                    Text(
+                        text = event,
+                        fontFamily = FontFamily.Monospace,
+                        modifier = Modifier.padding(vertical = 4.dp)
+                    )
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/example/kouki/fujisue/androidlab/ui/lifecycle/LifecycleViewModel.kt
+++ b/app/src/main/java/com/example/kouki/fujisue/androidlab/ui/lifecycle/LifecycleViewModel.kt
@@ -1,0 +1,29 @@
+package com.example.kouki.fujisue.androidlab.ui.lifecycle
+
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.ViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+
+/**
+ * ライフサイクルイベントのリストを管理するViewModel
+ */
+class LifecycleViewModel : ViewModel() {
+
+    // 外部には読み取り専用のStateFlowを公開し、ViewModel内でのみ値を変更できるようにする
+    private val _lifecycleEvents = MutableStateFlow<List<String>>(emptyList())
+    val lifecycleEvents: StateFlow<List<String>> = _lifecycleEvents
+
+    /**
+     * 新しいライフサイクルイベントをリストに追加します。
+     */
+    fun addEvent(event: Lifecycle.Event) {
+        val timestamp = SimpleDateFormat("HH:mm:ss.SSS", Locale.JAPAN).format(Date())
+        val newEvent = "$timestamp: ${event.name}"
+        // 現在のリストに新しいイベントを追加した新しいリストを生成してStateFlowを更新
+        _lifecycleEvents.value = _lifecycleEvents.value + newEvent
+    }
+}

--- a/app/src/main/java/com/example/kouki/fujisue/androidlab/ui/lifecycle/LifecycleViewModel.kt
+++ b/app/src/main/java/com/example/kouki/fujisue/androidlab/ui/lifecycle/LifecycleViewModel.kt
@@ -9,21 +9,24 @@ import java.util.Date
 import java.util.Locale
 
 /**
+ * ライフサイクルイベントのログ情報を保持するデータクラス
+ */
+data class LifecycleLog(val event: Lifecycle.Event, val timestamp: String)
+
+/**
  * ライフサイクルイベントのリストを管理するViewModel
  */
 class LifecycleViewModel : ViewModel() {
 
-    // 外部には読み取り専用のStateFlowを公開し、ViewModel内でのみ値を変更できるようにする
-    private val _lifecycleEvents = MutableStateFlow<List<String>>(emptyList())
-    val lifecycleEvents: StateFlow<List<String>> = _lifecycleEvents
+    private val _lifecycleEvents = MutableStateFlow<List<LifecycleLog>>(emptyList())
+    val lifecycleEvents: StateFlow<List<LifecycleLog>> = _lifecycleEvents
 
     /**
      * 新しいライフサイクルイベントをリストに追加します。
      */
     fun addEvent(event: Lifecycle.Event) {
         val timestamp = SimpleDateFormat("HH:mm:ss.SSS", Locale.JAPAN).format(Date())
-        val newEvent = "$timestamp: ${event.name}"
-        // 現在のリストに新しいイベントを追加した新しいリストを生成してStateFlowを更新
-        _lifecycleEvents.value = _lifecycleEvents.value + newEvent
+        val newLog = LifecycleLog(event, timestamp)
+        _lifecycleEvents.value = _lifecycleEvents.value + newLog
     }
 }

--- a/app/src/main/java/com/example/kouki/fujisue/androidlab/ui/main/MainScreen.kt
+++ b/app/src/main/java/com/example/kouki/fujisue/androidlab/ui/main/MainScreen.kt
@@ -40,7 +40,8 @@ fun MainScreen(navController: NavController) {
         Route.CameraScreen to "カメラ機能を学ぶ画面",
         Route.NetworkingScreen to "ネットワークリクエストとデータ表示を学ぶ画面",
         Route.StorageScreen to "データ永続化を学ぶ画面",
-        Route.LocationScreen to "GPS（位置情報）を学ぶ画面"
+        Route.LocationScreen to "GPS（位置情報）を学ぶ画面",
+        Route.LifecycleScreen to "ライフサイクルを学ぶ画面" // ★ ここに追加
     )
 
     Scaffold(

--- a/app/src/main/java/com/example/kouki/fujisue/androidlab/ui/navigation/Route.kt
+++ b/app/src/main/java/com/example/kouki/fujisue/androidlab/ui/navigation/Route.kt
@@ -91,4 +91,10 @@ object Route {
      */
     @Serializable
     data object LocationScreen
+
+    /**
+     * ライフサイクルを学ぶ画面
+     */
+    @Serializable
+    data object LifecycleScreen
 }


### PR DESCRIPTION
# アクティビティのライフサイクルを可視化

This pull request introduces a new feature to the app: a screen for observing and learning about Android lifecycle events using Jetpack Compose and ViewModel. The changes add the `LifecycleScreen` and its supporting ViewModel, update navigation routes, and integrate the new screen into the main navigation and UI.

**New Lifecycle Screen Feature:**

* Added a new composable screen `LifecycleScreen` that observes lifecycle events and displays a live log, including event name and timestamp, with color coding for different event types.
* Implemented `LifecycleViewModel` to manage and expose the list of lifecycle event logs using `StateFlow`, and a method to add new events with timestamps.

**Navigation and UI Integration:**

* Registered the new `LifecycleScreen` route in the navigation system (`Route.LifecycleScreen`) and updated the navigation composables to include it. [[1]](diffhunk://#diff-ada237a14372f32d72cb2aba065d6f8d85e6ceb6d4b57cf305fe745443f1bfbcR94-R99) [[2]](diffhunk://#diff-dff871803277c35be49c32e44f7df3ad2076a75c47e2912da873630fc77d259aR130-R132)
* Added the import for `LifecycleScreen` in `MainActivity.kt` to enable usage in navigation.
* Updated the main screen's navigation list to show "ライフサイクルを学ぶ画面" and route to the new lifecycle screen.