### PR TITLE
UIの状態保存を学習する

### DIFF
--- a/app/src/main/java/com/example/kouki/fujisue/androidlab/MainActivity.kt
+++ b/app/src/main/java/com/example/kouki/fujisue/androidlab/MainActivity.kt
@@ -31,6 +31,7 @@ import com.example.kouki.fujisue.androidlab.ui.networking.NetworkingScreen
 import com.example.kouki.fujisue.androidlab.ui.notification.NotificationScreen
 import com.example.kouki.fujisue.androidlab.ui.other.OtherScreen
 import com.example.kouki.fujisue.androidlab.ui.permission.PermissionsScreen
+import com.example.kouki.fujisue.androidlab.ui.savedinstancestate.SavedInstanceStateScreen
 import com.example.kouki.fujisue.androidlab.ui.sideeffect.SideEffectScreen
 import com.example.kouki.fujisue.androidlab.ui.storage.StorageScreen
 import com.example.kouki.fujisue.androidlab.ui.text.TextScreen
@@ -133,6 +134,9 @@ fun AppContent() {
             }
             composable<Route.ActivityResultScreen> {
                 ActivityResultScreen()
+            }
+            composable<Route.SavedInstanceStateScreen> {
+                SavedInstanceStateScreen()
             }
         }
     }

--- a/app/src/main/java/com/example/kouki/fujisue/androidlab/ui/main/MainScreen.kt
+++ b/app/src/main/java/com/example/kouki/fujisue/androidlab/ui/main/MainScreen.kt
@@ -42,7 +42,8 @@ fun MainScreen(navController: NavController) {
         Route.StorageScreen to "データ永続化を学ぶ画面",
         Route.LocationScreen to "GPS（位置情報）を学ぶ画面",
         Route.LifecycleScreen to "ライフサイクルを学ぶ画面",
-        Route.ActivityResultScreen to "ActivityResultを学ぶ画面"
+        Route.ActivityResultScreen to "ActivityResultを学ぶ画面",
+        Route.SavedInstanceStateScreen to "savedInstanceStateを学ぶ画面"
     )
 
     Scaffold(

--- a/app/src/main/java/com/example/kouki/fujisue/androidlab/ui/navigation/Route.kt
+++ b/app/src/main/java/com/example/kouki/fujisue/androidlab/ui/navigation/Route.kt
@@ -103,4 +103,10 @@ object Route {
      */
     @Serializable
     data object ActivityResultScreen
+
+    /**
+     * savedInstanceStateを学ぶ画面
+     */
+    @Serializable
+    data object SavedInstanceStateScreen
 }

--- a/app/src/main/java/com/example/kouki/fujisue/androidlab/ui/savedinstancestate/SavedInstanceStateScreen.kt
+++ b/app/src/main/java/com/example/kouki/fujisue/androidlab/ui/savedinstancestate/SavedInstanceStateScreen.kt
@@ -2,35 +2,49 @@ package com.example.kouki.fujisue.androidlab.ui.savedinstancestate
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import androidx.lifecycle.viewmodel.compose.viewModel
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun SavedInstanceStateScreen() {
-    var text by rememberSaveable { mutableStateOf("") }
-    var count by rememberSaveable { mutableStateOf(0) }
+fun SavedInstanceStateScreen(viewModel: SavedStateViewModel = viewModel()) {
+    // ViewModelから状態を取得
+    val vmCount by viewModel.vmCount.collectAsState()
+
+    // remember: 再コンポーズ間で状態を保持するが、Activityの再生成では保持されない
+    var rememberCount by remember { mutableStateOf(0) }
+
+    // rememberSaveable: Activityの再生成後も状態を保持する
+    var saveableCount by rememberSaveable { mutableStateOf(0) }
 
     Scaffold(
         topBar = {
             TopAppBar(
-                title = { Text("rememberSaveableの学習") },
+                title = { Text("状態保存の比較") },
                 colors = TopAppBarDefaults.topAppBarColors(
                     containerColor = MaterialTheme.colorScheme.primaryContainer,
                     titleContentColor = MaterialTheme.colorScheme.primary,
@@ -43,24 +57,58 @@ fun SavedInstanceStateScreen() {
                 .fillMaxSize()
                 .padding(paddingValues)
                 .padding(16.dp),
-            verticalArrangement = Arrangement.spacedBy(16.dp)
+            verticalArrangement = Arrangement.spacedBy(24.dp)
         ) {
-            Text(
-                text = "rememberSaveableは、Activityの再生成（画面回転など）やプロセスの再作成後も状態を保持します。カウンターとテキストフィールドの値を変更し、端末を回転させてみてください。",
-                style = MaterialTheme.typography.bodyLarge
+            // remember
+            StateCard(
+                title = "remember",
+                description = "再コンポーズ間でのみ状態を保持します。画面回転などでリセットされます。",
+                count = rememberCount,
+                onIncrement = { rememberCount++ }
             )
 
-            OutlinedTextField(
-                value = text,
-                onValueChange = { text = it },
-                label = { Text("状態が保存されるテキスト") },
+            // rememberSaveable
+            StateCard(
+                title = "rememberSaveable",
+                description = "画面回転やプロセスの再作成後も状態を保持します。",
+                count = saveableCount,
+                onIncrement = { saveableCount++ }
+            )
+
+            // ViewModel with SavedStateHandle
+            StateCard(
+                title = "ViewModel & SavedStateHandle",
+                description = "画面回転、プロセスの再作成、さらに画面（Composable）が破棄されても状態を保持します。",
+                count = vmCount,
+                onIncrement = { viewModel.incrementVmCount() }
+            )
+        }
+    }
+}
+
+/**
+ * 各状態保存方法のカウンターと説明を表示する共通のカードUI
+ */
+@Composable
+fun StateCard(title: String, description: String, count: Int, onIncrement: () -> Unit) {
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        elevation = CardDefaults.cardElevation(defaultElevation = 4.dp)
+    ) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Text(text = title, style = MaterialTheme.typography.headlineSmall)
+            Spacer(modifier = Modifier.height(8.dp))
+            Text(text = description, style = MaterialTheme.typography.bodyMedium)
+            Spacer(modifier = Modifier.height(16.dp))
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.SpaceBetween,
                 modifier = Modifier.fillMaxWidth()
-            )
-
-            Text("カウンター: $count", style = MaterialTheme.typography.headlineMedium)
-
-            Button(onClick = { count++ }) {
-                Text("カウンターを増やす")
+            ) {
+                Text(text = "Count: $count", style = MaterialTheme.typography.titleLarge)
+                Button(onClick = onIncrement) {
+                    Text("Increment")
+                }
             }
         }
     }

--- a/app/src/main/java/com/example/kouki/fujisue/androidlab/ui/savedinstancestate/SavedInstanceStateScreen.kt
+++ b/app/src/main/java/com/example/kouki/fujisue/androidlab/ui/savedinstancestate/SavedInstanceStateScreen.kt
@@ -34,6 +34,7 @@ import androidx.lifecycle.viewmodel.compose.viewModel
 fun SavedInstanceStateScreen(viewModel: SavedStateViewModel = viewModel()) {
     // ViewModelから状態を取得
     val vmCount by viewModel.vmCount.collectAsState()
+    val plainVmCount by viewModel.plainVmCount.collectAsState()
 
     // remember: 再コンポーズ間で状態を保持するが、Activityの再生成では保持されない
     var rememberCount by remember { mutableStateOf(0) }
@@ -57,7 +58,7 @@ fun SavedInstanceStateScreen(viewModel: SavedStateViewModel = viewModel()) {
                 .fillMaxSize()
                 .padding(paddingValues)
                 .padding(16.dp),
-            verticalArrangement = Arrangement.spacedBy(24.dp)
+            verticalArrangement = Arrangement.spacedBy(16.dp)
         ) {
             // remember
             StateCard(
@@ -75,10 +76,18 @@ fun SavedInstanceStateScreen(viewModel: SavedStateViewModel = viewModel()) {
                 onIncrement = { saveableCount++ }
             )
 
+            // ViewModel without SavedStateHandle
+            StateCard(
+                title = "ViewModel (Plain)",
+                description = "ViewModel内で状態を保持します。画面回転では維持されますが、プロセスの再作成でリセットされます。",
+                count = plainVmCount,
+                onIncrement = { viewModel.incrementPlainVmCount() }
+            )
+
             // ViewModel with SavedStateHandle
             StateCard(
                 title = "ViewModel & SavedStateHandle",
-                description = "画面回転、プロセスの再作成、さらに画面（Composable）が破棄されても状態を保持します。",
+                description = "SavedStateHandleにより、プロセスの再作成後も状態を復元できます。最も堅牢な方法です。",
                 count = vmCount,
                 onIncrement = { viewModel.incrementVmCount() }
             )

--- a/app/src/main/java/com/example/kouki/fujisue/androidlab/ui/savedinstancestate/SavedInstanceStateScreen.kt
+++ b/app/src/main/java/com/example/kouki/fujisue/androidlab/ui/savedinstancestate/SavedInstanceStateScreen.kt
@@ -1,0 +1,67 @@
+package com.example.kouki.fujisue.androidlab.ui.savedinstancestate
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Button
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun SavedInstanceStateScreen() {
+    var text by rememberSaveable { mutableStateOf("") }
+    var count by rememberSaveable { mutableStateOf(0) }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("rememberSaveableの学習") },
+                colors = TopAppBarDefaults.topAppBarColors(
+                    containerColor = MaterialTheme.colorScheme.primaryContainer,
+                    titleContentColor = MaterialTheme.colorScheme.primary,
+                )
+            )
+        }
+    ) { paddingValues ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(paddingValues)
+                .padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(16.dp)
+        ) {
+            Text(
+                text = "rememberSaveableは、Activityの再生成（画面回転など）やプロセスの再作成後も状態を保持します。カウンターとテキストフィールドの値を変更し、端末を回転させてみてください。",
+                style = MaterialTheme.typography.bodyLarge
+            )
+
+            OutlinedTextField(
+                value = text,
+                onValueChange = { text = it },
+                label = { Text("状態が保存されるテキスト") },
+                modifier = Modifier.fillMaxWidth()
+            )
+
+            Text("カウンター: $count", style = MaterialTheme.typography.headlineMedium)
+
+            Button(onClick = { count++ }) {
+                Text("カウンターを増やす")
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/example/kouki/fujisue/androidlab/ui/savedinstancestate/SavedStateViewModel.kt
+++ b/app/src/main/java/com/example/kouki/fujisue/androidlab/ui/savedinstancestate/SavedStateViewModel.kt
@@ -2,19 +2,32 @@ package com.example.kouki.fujisue.androidlab.ui.savedinstancestate
 
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 
 /**
  * SavedInstanceStateScreenの状態を管理するViewModel。
- * SavedStateHandleを使用して、プロセスの再作成後も状態を復元します。
+ * SavedStateHandleを使用する場合としない場合の状態保持の違いを比較します。
  */
 class SavedStateViewModel(private val savedStateHandle: SavedStateHandle) : ViewModel() {
 
-    // "vm_count"というキーでカウンターの状態を公開します。
+    // SavedStateHandleに保存されないカウンター。プロセスの再作成で失われます。
+    private val _plainVmCount = MutableStateFlow(0)
+    val plainVmCount: StateFlow<Int> = _plainVmCount.asStateFlow()
+
+    // SavedStateHandleに保存されるカウンター。プロセスの再作成後も復元されます。
     val vmCount: StateFlow<Int> = savedStateHandle.getStateFlow(KEY_VM_COUNT, 0)
 
     /**
-     * ViewModelのカウンターをインクリメントし、SavedStateHandleに保存します。
+     * SavedStateHandleを使用しないカウンターをインクリメントします。
+     */
+    fun incrementPlainVmCount() {
+        _plainVmCount.value++
+    }
+
+    /**
+     * SavedStateHandleに保存されたカウンターをインクリメントします。
      */
     fun incrementVmCount() {
         val currentCount = vmCount.value

--- a/app/src/main/java/com/example/kouki/fujisue/androidlab/ui/savedinstancestate/SavedStateViewModel.kt
+++ b/app/src/main/java/com/example/kouki/fujisue/androidlab/ui/savedinstancestate/SavedStateViewModel.kt
@@ -1,0 +1,27 @@
+package com.example.kouki.fujisue.androidlab.ui.savedinstancestate
+
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModel
+import kotlinx.coroutines.flow.StateFlow
+
+/**
+ * SavedInstanceStateScreenの状態を管理するViewModel。
+ * SavedStateHandleを使用して、プロセスの再作成後も状態を復元します。
+ */
+class SavedStateViewModel(private val savedStateHandle: SavedStateHandle) : ViewModel() {
+
+    // "vm_count"というキーでカウンターの状態を公開します。
+    val vmCount: StateFlow<Int> = savedStateHandle.getStateFlow(KEY_VM_COUNT, 0)
+
+    /**
+     * ViewModelのカウンターをインクリメントし、SavedStateHandleに保存します。
+     */
+    fun incrementVmCount() {
+        val currentCount = vmCount.value
+        savedStateHandle[KEY_VM_COUNT] = currentCount + 1
+    }
+
+    companion object {
+        private const val KEY_VM_COUNT = "vm_count"
+    }
+}


### PR DESCRIPTION
# UIの状態保存を学習する

This pull request adds a new screen to demonstrate different state-saving mechanisms in Jetpack Compose, including `remember`, `rememberSaveable`, and ViewModel usage with and without `SavedStateHandle`. The changes include the implementation of the new screen, updates to navigation, and integration into the main UI.

**New Feature: State Saving Demo Screen**

* Added `SavedInstanceStateScreen` to illustrate and compare four state-saving approaches: `remember`, `rememberSaveable`, ViewModel, and ViewModel with `SavedStateHandle`. The screen provides interactive counters and explanations for each method. (`app/src/main/java/com/example/kouki/fujisue/androidlab/ui/savedinstancestate/SavedInstanceStateScreen.kt`)
* Implemented `SavedStateViewModel` to support the new screen, showing the difference between plain ViewModel state and `SavedStateHandle`-backed state. (`app/src/main/java/com/example/kouki/fujisue/androidlab/ui/savedinstancestate/SavedStateViewModel.kt`)

**Navigation and UI Integration**

* Registered the new route `SavedInstanceStateScreen` in the navigation system, enabling navigation to the demo screen. (`app/src/main/java/com/example/kouki/fujisue/androidlab/ui/navigation/Route.kt`)
* Updated `MainScreen` to include the new screen in the menu, with a descriptive label. (`app/src/main/java/com/example/kouki/fujisue/androidlab/ui/main/MainScreen.kt`)
* Integrated the new composable into the navigation graph, allowing users to access the state-saving demo from the app. (`app/src/main/java/com/example/kouki/fujisue/androidlab/MainActivity.kt`) [[1]](diffhunk://#diff-dff871803277c35be49c32e44f7df3ad2076a75c47e2912da873630fc77d259aR34) [[2]](diffhunk://#diff-dff871803277c35be49c32e44f7df3ad2076a75c47e2912da873630fc77d259aR138-R140)