### PR TITLE
work managerを追加

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -61,6 +61,7 @@ dependencies {
     implementation(libs.coil.compose)
     implementation(libs.androidx.ui.graphics)
     implementation(libs.androidx.constraintlayout.compose)
+    implementation(libs.androidx.work.work.runtime)
 
     implementation(libs.ktor.client.core)
     implementation(libs.ktor.client.okhttp)

--- a/app/src/main/java/com/example/kouki/fujisue/androidlab/MainActivity.kt
+++ b/app/src/main/java/com/example/kouki/fujisue/androidlab/MainActivity.kt
@@ -39,6 +39,7 @@ import com.example.kouki.fujisue.androidlab.ui.theme.AndroidLabTheme
 import com.example.kouki.fujisue.androidlab.ui.theming.ThemeMode
 import com.example.kouki.fujisue.androidlab.ui.theming.ThemingScreen
 import com.example.kouki.fujisue.androidlab.ui.touching.TouchingScreen
+import com.example.kouki.fujisue.androidlab.ui.workmanager.WorkManagerScreen
 
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -137,6 +138,9 @@ fun AppContent() {
             }
             composable<Route.SavedInstanceStateScreen> {
                 SavedInstanceStateScreen()
+            }
+            composable<Route.WorkManagerScreen> {
+                WorkManagerScreen()
             }
         }
     }

--- a/app/src/main/java/com/example/kouki/fujisue/androidlab/ui/main/MainScreen.kt
+++ b/app/src/main/java/com/example/kouki/fujisue/androidlab/ui/main/MainScreen.kt
@@ -43,7 +43,8 @@ fun MainScreen(navController: NavController) {
         Route.LocationScreen to "GPS（位置情報）を学ぶ画面",
         Route.LifecycleScreen to "ライフサイクルを学ぶ画面",
         Route.ActivityResultScreen to "ActivityResultを学ぶ画面",
-        Route.SavedInstanceStateScreen to "savedInstanceStateを学ぶ画面"
+        Route.SavedInstanceStateScreen to "savedInstanceStateを学ぶ画面",
+        Route.WorkManagerScreen to "WorkManagerを学ぶ画面"
     )
 
     Scaffold(

--- a/app/src/main/java/com/example/kouki/fujisue/androidlab/ui/navigation/Route.kt
+++ b/app/src/main/java/com/example/kouki/fujisue/androidlab/ui/navigation/Route.kt
@@ -109,4 +109,10 @@ object Route {
      */
     @Serializable
     data object SavedInstanceStateScreen
+
+    /**
+     * WorkManagerを学ぶ画面
+     */
+    @Serializable
+    data object WorkManagerScreen
 }

--- a/app/src/main/java/com/example/kouki/fujisue/androidlab/ui/workmanager/WorkManagerScreen.kt
+++ b/app/src/main/java/com/example/kouki/fujisue/androidlab/ui/workmanager/WorkManagerScreen.kt
@@ -2,11 +2,15 @@ package com.example.kouki.fujisue.androidlab.ui.workmanager
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
@@ -19,27 +23,40 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
+import androidx.work.ExistingPeriodicWorkPolicy
 import androidx.work.OneTimeWorkRequestBuilder
+import androidx.work.PeriodicWorkRequestBuilder
 import androidx.work.WorkInfo
 import androidx.work.WorkManager
+import com.example.kouki.fujisue.androidlab.worker.NotificationWorker
 import com.example.kouki.fujisue.androidlab.worker.SimpleWorker
 import java.util.UUID
+import java.util.concurrent.TimeUnit
+
+const val PERIODIC_WORK_TAG = "periodic_notification_work"
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun WorkManagerScreen() {
     val context = LocalContext.current
     val workManager = WorkManager.getInstance(context)
-    var workId by remember { mutableStateOf<UUID?>(null) }
+    var oneTimeWorkId by remember { mutableStateOf<UUID?>(null) }
 
-    val flow = remember(workId) {
-        workId?.let { workManager.getWorkInfoByIdFlow(it) }
-    }
-    val workInfo by flow?.collectAsState(null) ?: remember { mutableStateOf(null) }
+    // 1回限りのタスクの状態を監視
+    val oneTimeWorkInfo by remember(oneTimeWorkId) {
+        oneTimeWorkId?.let { workManager.getWorkInfoByIdFlow(it) }
+    }?.collectAsState(initial = null) ?: remember { mutableStateOf(null) }
 
+    // 定期実行タスクの状態を監視
+    val periodicWorkInfo by workManager.getWorkInfosByTagFlow(PERIODIC_WORK_TAG)
+        .collectAsState(initial = emptyList())
+
+    val isPeriodicWorkScheduled =
+        periodicWorkInfo.any { it.state == WorkInfo.State.ENQUEUED || it.state == WorkInfo.State.RUNNING }
 
     Scaffold(
         topBar = {
@@ -59,32 +76,81 @@ fun WorkManagerScreen() {
                 .padding(16.dp),
             verticalArrangement = Arrangement.spacedBy(16.dp)
         ) {
-            Text(
-                text = "WorkManagerは、即時実行、長時間実行、および遅延実行が可能な、保証付きの非同期タスクをスケジュールするためのライブラリです。下のボタンを押すと、5秒間待機する単純なバックグラウンドタスクが開始されます。",
-                style = MaterialTheme.typography.bodyLarge
+            // 1回限りのタスク
+            TaskCard(
+                title = "1回限りのタスク",
+                description = "5秒間待機する単純なバックグラウンドタスクです。",
+                buttonText = "タスクを開始",
+                buttonEnabled = oneTimeWorkInfo?.state != WorkInfo.State.RUNNING,
+                status = when (oneTimeWorkInfo?.state) {
+                    WorkInfo.State.ENQUEUED -> "状態: キューに追加されました"
+                    WorkInfo.State.RUNNING -> "状態: 実行中..."
+                    WorkInfo.State.SUCCEEDED -> "状態: 正常に完了しました"
+                    WorkInfo.State.FAILED -> "状態: 失敗しました"
+                    WorkInfo.State.BLOCKED -> "状態: ブロックされています"
+                    WorkInfo.State.CANCELLED -> "状態: キャンセルされました"
+                    else -> "状態: 開始されていません"
+                },
+                onButtonClick = {
+                    val workRequest = OneTimeWorkRequestBuilder<SimpleWorker>().build()
+                    oneTimeWorkId = workRequest.id
+                    workManager.enqueue(workRequest)
+                }
             )
 
-            Button(
-                onClick = {
-                    val workRequest = OneTimeWorkRequestBuilder<SimpleWorker>().build()
-                    workId = workRequest.id
-                    workManager.enqueue(workRequest)
-                },
-                enabled = workInfo?.state != WorkInfo.State.RUNNING
+            // 定期実行タスク
+            TaskCard(
+                title = "定期実行タスク",
+                description = "15分ごとに通知を表示するタスクをスケジュールします。",
+                buttonText = if (isPeriodicWorkScheduled) "タスクをキャンセル" else "タスクを開始",
+                buttonEnabled = true,
+                status = if (isPeriodicWorkScheduled) "状態: スケジュール済み" else "状態: 停止中",
+                onButtonClick = {
+                    if (isPeriodicWorkScheduled) {
+                        workManager.cancelAllWorkByTag(PERIODIC_WORK_TAG)
+                    } else {
+                        val periodicWorkRequest = PeriodicWorkRequestBuilder<NotificationWorker>(
+                            15, TimeUnit.MINUTES
+                        ).addTag(PERIODIC_WORK_TAG).build()
+                        workManager.enqueueUniquePeriodicWork(
+                            PERIODIC_WORK_TAG,
+                            ExistingPeriodicWorkPolicy.KEEP,
+                            periodicWorkRequest
+                        )
+                    }
+                }
+            )
+        }
+    }
+}
+
+@Composable
+fun TaskCard(
+    title: String,
+    description: String,
+    buttonText: String,
+    buttonEnabled: Boolean,
+    status: String,
+    onButtonClick: () -> Unit
+) {
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        elevation = CardDefaults.cardElevation(defaultElevation = 2.dp)
+    ) {
+        Column(Modifier.padding(16.dp)) {
+            Text(text = title, style = MaterialTheme.typography.titleLarge)
+            Spacer(Modifier.height(8.dp))
+            Text(text = description, style = MaterialTheme.typography.bodyMedium)
+            Spacer(Modifier.height(16.dp))
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.SpaceBetween,
+                modifier = Modifier.fillMaxWidth()
             ) {
-                Text("バックグラウンドタスクを開始")
-            }
-
-            Spacer(modifier = Modifier.height(16.dp))
-
-            when (workInfo?.state) {
-                WorkInfo.State.ENQUEUED -> Text("状態: タスクはキューに追加されました")
-                WorkInfo.State.RUNNING -> Text("状態: タスク実行中...")
-                WorkInfo.State.SUCCEEDED -> Text("状態: タスクは正常に完了しました")
-                WorkInfo.State.FAILED -> Text("状態: タスクは失敗しました")
-                WorkInfo.State.BLOCKED -> Text("状態: タスクはブロックされています")
-                WorkInfo.State.CANCELLED -> Text("状態: タスクはキャンセルされました")
-                null -> Text("状態: タスクはまだ開始されていません")
+                Text(text = status, style = MaterialTheme.typography.bodySmall)
+                Button(onClick = onButtonClick, enabled = buttonEnabled) {
+                    Text(buttonText)
+                }
             }
         }
     }

--- a/app/src/main/java/com/example/kouki/fujisue/androidlab/ui/workmanager/WorkManagerScreen.kt
+++ b/app/src/main/java/com/example/kouki/fujisue/androidlab/ui/workmanager/WorkManagerScreen.kt
@@ -1,0 +1,91 @@
+package com.example.kouki.fujisue.androidlab.ui.workmanager
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Button
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.unit.dp
+import androidx.work.OneTimeWorkRequestBuilder
+import androidx.work.WorkInfo
+import androidx.work.WorkManager
+import com.example.kouki.fujisue.androidlab.worker.SimpleWorker
+import java.util.UUID
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun WorkManagerScreen() {
+    val context = LocalContext.current
+    val workManager = WorkManager.getInstance(context)
+    var workId by remember { mutableStateOf<UUID?>(null) }
+
+    val flow = remember(workId) {
+        workId?.let { workManager.getWorkInfoByIdFlow(it) }
+    }
+    val workInfo by flow?.collectAsState(null) ?: remember { mutableStateOf(null) }
+
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("WorkManagerの学習") },
+                colors = TopAppBarDefaults.topAppBarColors(
+                    containerColor = MaterialTheme.colorScheme.primaryContainer,
+                    titleContentColor = MaterialTheme.colorScheme.primary,
+                )
+            )
+        }
+    ) { paddingValues ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(paddingValues)
+                .padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(16.dp)
+        ) {
+            Text(
+                text = "WorkManagerは、即時実行、長時間実行、および遅延実行が可能な、保証付きの非同期タスクをスケジュールするためのライブラリです。下のボタンを押すと、5秒間待機する単純なバックグラウンドタスクが開始されます。",
+                style = MaterialTheme.typography.bodyLarge
+            )
+
+            Button(
+                onClick = {
+                    val workRequest = OneTimeWorkRequestBuilder<SimpleWorker>().build()
+                    workId = workRequest.id
+                    workManager.enqueue(workRequest)
+                },
+                enabled = workInfo?.state != WorkInfo.State.RUNNING
+            ) {
+                Text("バックグラウンドタスクを開始")
+            }
+
+            Spacer(modifier = Modifier.height(16.dp))
+
+            when (workInfo?.state) {
+                WorkInfo.State.ENQUEUED -> Text("状態: タスクはキューに追加されました")
+                WorkInfo.State.RUNNING -> Text("状態: タスク実行中...")
+                WorkInfo.State.SUCCEEDED -> Text("状態: タスクは正常に完了しました")
+                WorkInfo.State.FAILED -> Text("状態: タスクは失敗しました")
+                WorkInfo.State.BLOCKED -> Text("状態: タスクはブロックされています")
+                WorkInfo.State.CANCELLED -> Text("状態: タスクはキャンセルされました")
+                null -> Text("状態: タスクはまだ開始されていません")
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/example/kouki/fujisue/androidlab/worker/NotificationWorker.kt
+++ b/app/src/main/java/com/example/kouki/fujisue/androidlab/worker/NotificationWorker.kt
@@ -1,0 +1,82 @@
+package com.example.kouki.fujisue.androidlab.worker
+
+import android.Manifest
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.content.Context
+import android.content.pm.PackageManager
+import android.os.Build
+import android.util.Log
+import androidx.core.app.ActivityCompat
+import androidx.core.app.NotificationCompat
+import androidx.core.app.NotificationManagerCompat
+import androidx.work.CoroutineWorker
+import androidx.work.WorkerParameters
+import com.example.kouki.fujisue.androidlab.R
+
+/**
+ * 定期的に通知を表示するワーカー。
+ */
+class NotificationWorker(private val appContext: Context, workerParams: WorkerParameters) :
+    CoroutineWorker(appContext, workerParams) {
+
+    override suspend fun doWork(): Result {
+        Log.d(TAG, "定期実行タスクを開始します")
+
+        showNotification("WorkManager Demo", "定期的なバックグラウンドタスクが実行されました。")
+
+        Log.d(TAG, "定期実行タスクが正常に完了しました")
+        return Result.success()
+    }
+
+    /**
+     * 通知を表示します。
+     *
+     * @param title 通知のタイトル
+     * @param content 通知の本文
+     */
+    private fun showNotification(title: String, content: String) {
+        // Android O以降では、通知を表示するために通知チャネルの登録が必要です。
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            val name = "WorkManager Demo Channel"
+            val descriptionText = "Channel for WorkManager demo notifications"
+            val importance = NotificationManager.IMPORTANCE_DEFAULT
+            val channel = NotificationChannel(CHANNEL_ID, name, importance).apply {
+                description = descriptionText
+            }
+            // システムに通知チャネルを登録します。
+            val notificationManager: NotificationManager =
+                appContext.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+            notificationManager.createNotificationChannel(channel)
+        }
+
+        val builder = NotificationCompat.Builder(appContext, CHANNEL_ID)
+            .setSmallIcon(R.drawable.ic_launcher_foreground)
+            .setContentTitle(title)
+            .setContentText(content)
+            .setPriority(NotificationCompat.PRIORITY_DEFAULT)
+            .setAutoCancel(true)
+
+        // POST_NOTIFICATIONSパーミッションのチェック（API 33+）
+        if (ActivityCompat.checkSelfPermission(
+                appContext,
+                Manifest.permission.POST_NOTIFICATIONS
+            ) != PackageManager.PERMISSION_GRANTED
+        ) {
+            // パーミッションがない場合、ワーカーは通知を表示できません。
+            // 実際のアプリでは、タスクをスケジュールする前にUI層でパーミッションを要求する必要があります。
+            Log.e(TAG, "POST_NOTIFICATIONS permission not granted.")
+            return
+        }
+
+        with(NotificationManagerCompat.from(appContext)) {
+            notify(NOTIFICATION_ID, builder.build())
+        }
+    }
+
+    companion object {
+        private const val TAG = "NotificationWorker"
+        private const val CHANNEL_ID = "workmanager_channel"
+        private const val NOTIFICATION_ID = 1
+    }
+}

--- a/app/src/main/java/com/example/kouki/fujisue/androidlab/worker/SimpleWorker.kt
+++ b/app/src/main/java/com/example/kouki/fujisue/androidlab/worker/SimpleWorker.kt
@@ -1,0 +1,34 @@
+package com.example.kouki.fujisue.androidlab.worker
+
+import android.content.Context
+import android.util.Log
+import androidx.work.CoroutineWorker
+import androidx.work.WorkerParameters
+import kotlinx.coroutines.delay
+
+/**
+ * シンプルなバックグラウンドタスクを実行するワーカー。
+ * 5秒待機し、ログを出力します。
+ */
+class SimpleWorker(appContext: Context, workerParams: WorkerParameters) :
+    CoroutineWorker(appContext, workerParams) {
+
+    override suspend fun doWork(): Result {
+        Log.d(TAG, "バックグラウンドタスクを開始します")
+
+        try {
+            // 5秒待機する（時間のかかる処理をシミュレート）
+            delay(5000)
+        } catch (e: InterruptedException) {
+            Log.e(TAG, "タスクが中断されました", e)
+            return Result.failure()
+        }
+
+        Log.d(TAG, "バックグラウンドタスクが正常に完了しました")
+        return Result.success()
+    }
+
+    companion object {
+        private const val TAG = "SimpleWorker"
+    }
+}

--- a/app/src/main/java/com/example/kouki/fujisue/androidlab/worker/SimpleWorker.kt
+++ b/app/src/main/java/com/example/kouki/fujisue/androidlab/worker/SimpleWorker.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.util.Log
 import androidx.work.CoroutineWorker
 import androidx.work.WorkerParameters
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.delay
 
 /**
@@ -19,9 +20,10 @@ class SimpleWorker(appContext: Context, workerParams: WorkerParameters) :
         try {
             // 5秒待機する（時間のかかる処理をシミュレート）
             delay(5000)
-        } catch (e: InterruptedException) {
-            Log.e(TAG, "タスクが中断されました", e)
-            return Result.failure()
+        } catch (e: CancellationException) {
+            Log.w(TAG, "バックグラウンドタスクがキャンセルされました", e)
+            // キャンセル例外を再スローして、WorkManagerにキャンセルを正しく伝えます
+            throw e
         }
 
         Log.d(TAG, "バックグラウンドタスクが正常に完了しました")

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -15,6 +15,7 @@ coil = "2.7.0"
 constraintlayout = "1.1.1"
 room_version = "2.8.0"
 google_services = "21.3.0"
+work_version = "2.10.4"
 
 
 [libraries]
@@ -59,6 +60,9 @@ androidx-room-room-ktx = { group = "androidx.room", name = "room-ktx", version.r
 
 # Location
 play-services-location = { group = "com.google.android.gms", name = "play-services-location", version.ref = "google_services" }
+
+# WorkManager
+androidx-work-work-runtime = { group = "androidx.work", name = "work-runtime-ktx", version.ref = "work_version" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
# work managerを追加

This pull request adds a new WorkManager demonstration screen to the app, allowing users to experiment with background task scheduling and notification delivery. It introduces two new worker classes for one-time and periodic background tasks, integrates WorkManager dependencies, and updates navigation and UI to support the new feature.

**WorkManager feature integration:**

* Added `WorkManagerScreen` (`WorkManagerScreen.kt`) to demonstrate one-time and periodic background tasks, including UI for starting/canceling tasks and monitoring their status.
* Implemented `NotificationWorker` for periodic notifications and `SimpleWorker` for a one-time background task with logging and delay. [[1]](diffhunk://#diff-37752be26762fddafb549948d425e8dd392071fbd8aa1325238185095730531fR1-R82) [[2]](diffhunk://#diff-457e42a4d55b9fb96b91c23c8fe79140ed68d27b53c878e1794b1e51d0eb82baR1-R34)
* Added WorkManager dependency (`androidx.work.work.runtime`) to `build.gradle.kts` and defined its version in `libs.versions.toml`. [[1]](diffhunk://#diff-8cff73265af19c059547b76aca8882cbaa3209291406f52df1dafbbc78e80c46R64) [[2]](diffhunk://#diff-697f70cdd88ba88fe77eebda60c7e143f6ad1286bca75017421e93ad84fb87dfR18) [[3]](diffhunk://#diff-697f70cdd88ba88fe77eebda60c7e143f6ad1286bca75017421e93ad84fb87dfR64-R66)

**Navigation and UI updates:**

* Introduced `WorkManagerScreen` route in `Route.kt` and updated navigation logic to include the new screen. [[1]](diffhunk://#diff-ada237a14372f32d72cb2aba065d6f8d85e6ceb6d4b57cf305fe745443f1bfbcR112-R117) [[2]](diffhunk://#diff-dff871803277c35be49c32e44f7df3ad2076a75c47e2912da873630fc77d259aR142-R144)
* Updated `MainScreen` to list "WorkManagerを学ぶ画面" in the menu, enabling access to the new feature.
* Imported and referenced `WorkManagerScreen` in `MainActivity.kt` to complete integration.