### PR TITLE
スクロールと連動するUIを学ぶ画面

### DIFF
--- a/app/src/main/java/com/example/kouki/fujisue/androidlab/MainActivity.kt
+++ b/app/src/main/java/com/example/kouki/fujisue/androidlab/MainActivity.kt
@@ -18,6 +18,7 @@ import com.example.kouki.fujisue.androidlab.ui.activityresult.ActivityResultScre
 import com.example.kouki.fujisue.androidlab.ui.animation.AnimationScreen
 import com.example.kouki.fujisue.androidlab.ui.button.ButtonScreen
 import com.example.kouki.fujisue.androidlab.ui.camera.CameraScreen
+import com.example.kouki.fujisue.androidlab.ui.collapsing.CollapsingToolbarScreen
 import com.example.kouki.fujisue.androidlab.ui.dialog.DialogScreen
 import com.example.kouki.fujisue.androidlab.ui.image.ImageScreen
 import com.example.kouki.fujisue.androidlab.ui.input.InputScreen
@@ -141,6 +142,9 @@ fun AppContent() {
             }
             composable<Route.WorkManagerScreen> {
                 WorkManagerScreen()
+            }
+            composable<Route.CollapsingToolbarScreen> {
+                CollapsingToolbarScreen()
             }
         }
     }

--- a/app/src/main/java/com/example/kouki/fujisue/androidlab/ui/collapsing/CollapsingToolbarScreen.kt
+++ b/app/src/main/java/com/example/kouki/fujisue/androidlab/ui/collapsing/CollapsingToolbarScreen.kt
@@ -1,0 +1,57 @@
+package com.example.kouki.fujisue.androidlab.ui.collapsing
+
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.LargeTopAppBar
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.material3.rememberTopAppBarState
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.nestedscroll.nestedScroll
+import androidx.compose.ui.unit.dp
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun CollapsingToolbarScreen() {
+    // スクロール状態を監視・制御するための状態オブジェクトを作成します。
+    val scrollBehavior =
+        TopAppBarDefaults.exitUntilCollapsedScrollBehavior(rememberTopAppBarState())
+
+    // ScaffoldにnestedScrollモディファイアを適用し、スクロールイベントをTopAppBarに連携させます。
+    Scaffold(
+        modifier = Modifier.nestedScroll(scrollBehavior.nestedScrollConnection),
+        topBar = {
+            // LargeTopAppBarは、スクロールに応じてサイズが変化するTopAppBarです。
+            LargeTopAppBar(
+                title = { Text("Collapsing Toolbar") },
+                // scrollBehaviorをTopAppBarに渡すことで、スクロールと連動するようになります。
+                scrollBehavior = scrollBehavior,
+                colors = TopAppBarDefaults.largeTopAppBarColors(
+                    containerColor = MaterialTheme.colorScheme.primaryContainer,
+                    scrolledContainerColor = MaterialTheme.colorScheme.primaryContainer,
+                    titleContentColor = MaterialTheme.colorScheme.primary,
+                )
+            )
+        }
+    ) { innerPadding ->
+        // LazyColumnは、スクロール可能なコンテンツです。
+        // innerPaddingを適用することで、コンテンツがTopAppBarの下に隠れないようにします。
+        LazyColumn(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(innerPadding)
+        ) {
+            items(100) { index ->
+                Text(
+                    text = "Item #$index",
+                    modifier = Modifier.padding(16.dp)
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/example/kouki/fujisue/androidlab/ui/collapsing/CollapsingToolbarScreen.kt
+++ b/app/src/main/java/com/example/kouki/fujisue/androidlab/ui/collapsing/CollapsingToolbarScreen.kt
@@ -1,9 +1,17 @@
 package com.example.kouki.fujisue.androidlab.ui.collapsing
 
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.KeyboardArrowUp
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FloatingActionButton
+import androidx.compose.material3.Icon
 import androidx.compose.material3.LargeTopAppBar
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
@@ -11,25 +19,37 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.material3.rememberTopAppBarState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.unit.dp
+import kotlinx.coroutines.launch
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun CollapsingToolbarScreen() {
-    // スクロール状態を監視・制御するための状態オブジェクトを作成します。
+    // TopAppBarの状態を管理します
     val scrollBehavior =
         TopAppBarDefaults.exitUntilCollapsedScrollBehavior(rememberTopAppBarState())
+    // LazyColumnのスクロール状態を管理します
+    val listState = rememberLazyListState()
+    // コルーチンを起動するために使用します
+    val coroutineScope = rememberCoroutineScope()
 
-    // ScaffoldにnestedScrollモディファイアを適用し、スクロールイベントをTopAppBarに連携させます。
+    // FAB（フローティングアクションボタン）を表示するかどうかの状態を、リストのスクロール位置から派生させます。
+    // 最初のアイテムが見えなくなったらFABを表示します。
+    val isFabVisible by remember {
+        derivedStateOf { listState.firstVisibleItemIndex > 0 }
+    }
+
     Scaffold(
         modifier = Modifier.nestedScroll(scrollBehavior.nestedScrollConnection),
         topBar = {
-            // LargeTopAppBarは、スクロールに応じてサイズが変化するTopAppBarです。
             LargeTopAppBar(
                 title = { Text("Collapsing Toolbar") },
-                // scrollBehaviorをTopAppBarに渡すことで、スクロールと連動するようになります。
                 scrollBehavior = scrollBehavior,
                 colors = TopAppBarDefaults.largeTopAppBarColors(
                     containerColor = MaterialTheme.colorScheme.primaryContainer,
@@ -37,11 +57,32 @@ fun CollapsingToolbarScreen() {
                     titleContentColor = MaterialTheme.colorScheme.primary,
                 )
             )
+        },
+        floatingActionButton = {
+            // AnimatedVisibilityを使用して、FABの表示・非表示をアニメーションさせます。
+            AnimatedVisibility(
+                visible = isFabVisible,
+                enter = fadeIn(),
+                exit = fadeOut()
+            ) {
+                FloatingActionButton(
+                    onClick = {
+                        // FABをクリックすると、リストの先頭までスムーズにスクロールします。
+                        coroutineScope.launch {
+                            listState.animateScrollToItem(0)
+                        }
+                    },
+                ) {
+                    Icon(
+                        imageVector = Icons.Default.KeyboardArrowUp,
+                        contentDescription = "リストの先頭にスクロール"
+                    )
+                }
+            }
         }
     ) { innerPadding ->
-        // LazyColumnは、スクロール可能なコンテンツです。
-        // innerPaddingを適用することで、コンテンツがTopAppBarの下に隠れないようにします。
         LazyColumn(
+            state = listState, // LazyColumnに状態を渡します
             modifier = Modifier
                 .fillMaxSize()
                 .padding(innerPadding)

--- a/app/src/main/java/com/example/kouki/fujisue/androidlab/ui/main/MainScreen.kt
+++ b/app/src/main/java/com/example/kouki/fujisue/androidlab/ui/main/MainScreen.kt
@@ -44,7 +44,8 @@ fun MainScreen(navController: NavController) {
         Route.LifecycleScreen to "ライフサイクルを学ぶ画面",
         Route.ActivityResultScreen to "ActivityResultを学ぶ画面",
         Route.SavedInstanceStateScreen to "savedInstanceStateを学ぶ画面",
-        Route.WorkManagerScreen to "WorkManagerを学ぶ画面"
+        Route.WorkManagerScreen to "WorkManagerを学ぶ画面",
+        Route.CollapsingToolbarScreen to "スクロールと連動するUIを学ぶ画面"
     )
 
     Scaffold(

--- a/app/src/main/java/com/example/kouki/fujisue/androidlab/ui/navigation/Route.kt
+++ b/app/src/main/java/com/example/kouki/fujisue/androidlab/ui/navigation/Route.kt
@@ -115,4 +115,10 @@ object Route {
      */
     @Serializable
     data object WorkManagerScreen
+
+    /**
+     * スクロールと連動するUIを学ぶ画面
+     */
+    @Serializable
+    data object CollapsingToolbarScreen
 }


### PR DESCRIPTION
# スクロールと連動するUIを学ぶ画面

This pull request introduces a new screen for learning about scroll-linked UI using a Collapsing Toolbar in the app. It adds the `CollapsingToolbarScreen` implementation, integrates it into the navigation system, and updates the main menu to include this new feature.

**New Feature: Collapsing Toolbar Screen**
- Implemented a new composable screen `CollapsingToolbarScreen` that demonstrates a collapsing toolbar with a scrollable list and a floating action button that appears when the user scrolls down. The FAB animates and scrolls the list back to the top when clicked. (`app/src/main/java/com/example/kouki/fujisue/androidlab/ui/collapsing/CollapsingToolbarScreen.kt`)

**Navigation Integration**
- Added the new route `CollapsingToolbarScreen` to the navigation routes in `Route.kt`, with documentation for its purpose. (`app/src/main/java/com/example/kouki/fujisue/androidlab/ui/navigation/Route.kt`)
- Registered the new screen in the app's navigation graph so it can be accessed via routing. (`app/src/main/java/com/example/kouki/fujisue/androidlab/MainActivity.kt`) [[1]](diffhunk://#diff-dff871803277c35be49c32e44f7df3ad2076a75c47e2912da873630fc77d259aR21) [[2]](diffhunk://#diff-dff871803277c35be49c32e44f7df3ad2076a75c47e2912da873630fc77d259aR146-R148)

**Menu Update**
- Updated the main screen's menu to include an entry for the Collapsing Toolbar screen, labeled as "スクロールと連動するUIを学ぶ画面" (Learn about scroll-linked UI). (`app/src/main/java/com/example/kouki/fujisue/androidlab/ui/main/MainScreen.kt`)