### PR TITLE
ドラッグ＆ドロップで並べ替え可能なリスト学習項目を追加

### DIFF
--- a/app/src/main/java/com/example/kouki/fujisue/androidlab/MainActivity.kt
+++ b/app/src/main/java/com/example/kouki/fujisue/androidlab/MainActivity.kt
@@ -33,6 +33,7 @@ import com.example.kouki.fujisue.androidlab.ui.networking.NetworkingScreen
 import com.example.kouki.fujisue.androidlab.ui.notification.NotificationScreen
 import com.example.kouki.fujisue.androidlab.ui.other.OtherScreen
 import com.example.kouki.fujisue.androidlab.ui.permission.PermissionsScreen
+import com.example.kouki.fujisue.androidlab.ui.reorderablelist.ReorderableListScreen
 import com.example.kouki.fujisue.androidlab.ui.savedinstancestate.SavedInstanceStateScreen
 import com.example.kouki.fujisue.androidlab.ui.sideeffect.SideEffectScreen
 import com.example.kouki.fujisue.androidlab.ui.storage.StorageScreen
@@ -149,6 +150,9 @@ fun AppContent() {
             }
             composable<Route.CanvasScreen> {
                 CanvasScreen()
+            }
+            composable<Route.ReorderableListScreen> {
+                ReorderableListScreen()
             }
         }
     }

--- a/app/src/main/java/com/example/kouki/fujisue/androidlab/ui/main/MainScreen.kt
+++ b/app/src/main/java/com/example/kouki/fujisue/androidlab/ui/main/MainScreen.kt
@@ -46,7 +46,8 @@ fun MainScreen(navController: NavController) {
         Route.SavedInstanceStateScreen to "savedInstanceStateを学ぶ画面",
         Route.WorkManagerScreen to "WorkManagerを学ぶ画面",
         Route.CollapsingToolbarScreen to "スクロールと連動するUIを学ぶ画面",
-        Route.CanvasScreen to "カスタム描画とCanvasを学ぶ画面"
+        Route.CanvasScreen to "カスタム描画とCanvasを学ぶ画面",
+        Route.ReorderableListScreen to "ドラッグ＆ドロップで並べ替え可能なリストを学ぶ画面"
     )
 
     Scaffold(

--- a/app/src/main/java/com/example/kouki/fujisue/androidlab/ui/navigation/Route.kt
+++ b/app/src/main/java/com/example/kouki/fujisue/androidlab/ui/navigation/Route.kt
@@ -127,4 +127,10 @@ object Route {
      */
     @Serializable
     data object CanvasScreen
+
+    /**
+     * ドラッグ＆ドロップで並べ替え可能なリストを学ぶ画面
+     */
+    @Serializable
+    data object ReorderableListScreen
 }

--- a/app/src/main/java/com/example/kouki/fujisue/androidlab/ui/reorderablelist/ReorderableListScreen.kt
+++ b/app/src/main/java/com/example/kouki/fujisue/androidlab/ui/reorderablelist/ReorderableListScreen.kt
@@ -1,0 +1,180 @@
+package com.example.kouki.fujisue.androidlab.ui.reorderablelist
+
+import androidx.compose.foundation.gestures.detectDragGesturesAfterLongPress
+import androidx.compose.foundation.gestures.scrollBy
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyListState
+import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.material3.Card
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.unit.dp
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
+import java.util.Collections
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ReorderableListScreen() {
+    val items = remember {
+        mutableStateListOf(
+            "Item 1", "Item 2", "Item 3", "Item 4", "Item 5",
+            "Item 6", "Item 7", "Item 8", "Item 9", "Item 10"
+        )
+    }
+
+    val listState = rememberLazyListState()
+    val scope = rememberCoroutineScope()
+
+    var draggedIndex by remember { mutableIntStateOf(-1) }
+    var dragOffset by remember { mutableFloatStateOf(0f) }
+
+    val reorderableState = remember(items, listState, scope) {
+        ReorderableState(items, listState, scope)
+    }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("ドラッグ＆ドロップで並べ替え") },
+                colors = TopAppBarDefaults.topAppBarColors(
+                    containerColor = MaterialTheme.colorScheme.primaryContainer,
+                    titleContentColor = MaterialTheme.colorScheme.primary,
+                )
+            )
+        }
+    ) { paddingValues ->
+        LazyColumn(
+            state = listState,
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(paddingValues)
+        ) {
+            itemsIndexed(items, key = { _, item -> item }) { index, item ->
+                val isBeingDragged = index == draggedIndex
+                val currentOffset = if (isBeingDragged) dragOffset else 0f
+
+                // rememberUpdatedStateを使って、常に最新のindexを保持する
+                val currentIndex by rememberUpdatedState(index)
+
+                Card(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(vertical = 4.dp, horizontal = 16.dp)
+                        .graphicsLayer {
+                            translationY = currentOffset
+                            shadowElevation = if (isBeingDragged) 8.dp.toPx() else 1.dp.toPx()
+                        }
+                        .pointerInput(Unit) {
+                            detectDragGesturesAfterLongPress(
+                                onDragStart = {
+                                    // キャプチャされた古いindexの代わりに、最新のcurrentIndexを使用する
+                                    draggedIndex = currentIndex
+                                },
+                                onDrag = { change, dragAmount ->
+                                    change.consume()
+                                    dragOffset += dragAmount.y
+
+                                    val newDraggedIndex = reorderableState.onDrag(
+                                        draggedIndex = draggedIndex,
+                                        totalDragOffset = dragOffset
+                                    ) { adjustment ->
+                                        dragOffset += adjustment
+                                    }
+                                    draggedIndex = newDraggedIndex
+                                },
+                                onDragEnd = {
+                                    draggedIndex = -1
+                                    dragOffset = 0f
+                                },
+                                onDragCancel = {
+                                    draggedIndex = -1
+                                    dragOffset = 0f
+                                }
+                            )
+                        }
+                ) {
+                    Text(
+                        text = item,
+                        modifier = Modifier.padding(16.dp)
+                    )
+                }
+            }
+        }
+    }
+}
+
+private class ReorderableState(
+    private val items: MutableList<String>,
+    private val listState: LazyListState,
+    private val scope: CoroutineScope
+) {
+    fun onDrag(draggedIndex: Int, totalDragOffset: Float, adjustOffset: (Float) -> Unit): Int {
+        if (draggedIndex == -1) return -1
+
+        val draggedItemInfo =
+            listState.layoutInfo.visibleItemsInfo.firstOrNull { it.index == draggedIndex }
+        var newDraggedIndex = draggedIndex
+
+        if (draggedItemInfo != null) {
+            // --- 自動スクロール --- 
+            val itemTop = draggedItemInfo.offset + totalDragOffset
+            val itemBottom = itemTop + draggedItemInfo.size
+            val viewportTop = listState.layoutInfo.viewportStartOffset
+            val viewportBottom = listState.layoutInfo.viewportEndOffset
+            val scrollThreshold = (listState.layoutInfo.viewportSize.height * 0.1f)
+
+            scope.launch {
+                if (itemBottom > viewportBottom - scrollThreshold) {
+                    listState.scrollBy(30f) // 下へスクロール
+                } else if (itemTop < viewportTop + scrollThreshold) {
+                    listState.scrollBy(-30f) // 上へスクロール
+                }
+            }
+
+            // --- アイテムの入れ替え --- 
+            val draggedItemCenter =
+                draggedItemInfo.offset + totalDragOffset + (draggedItemInfo.size / 2)
+            val targetItemInfo = listState.layoutInfo.visibleItemsInfo.firstOrNull {
+                it.index != draggedIndex &&
+                        draggedItemCenter >= it.offset &&
+                        draggedItemCenter <= (it.offset + it.size)
+            }
+
+            if (targetItemInfo != null) {
+                val from = draggedIndex
+                val to = targetItemInfo.index
+                Collections.swap(items, from, to)
+
+                // ドラッグ対象のインデックスも更新
+                newDraggedIndex = to
+
+                // オフセットのジャンプを防ぐための補正
+                val offsetDifference =
+                    draggedItemInfo.offset.toFloat() - targetItemInfo.offset.toFloat()
+                adjustOffset(offsetDifference)
+            }
+        }
+        return newDraggedIndex
+    }
+}


### PR DESCRIPTION
# ドラッグ＆ドロップで並べ替え可能なリスト学習項目を追加

This pull request adds a new feature to the app: a screen for learning about reorderable lists using drag-and-drop. It introduces the `ReorderableListScreen`, integrates it into navigation, and updates the main UI to include this new screen. The implementation leverages Jetpack Compose and provides interactive drag-and-drop reordering with auto-scrolling.

**New feature: Reorderable list screen**

* Added a new composable screen `ReorderableListScreen` that demonstrates a drag-and-drop reorderable list using Jetpack Compose. The screen supports interactive item reordering and auto-scrolling during drag operations. (`app/src/main/java/com/example/kouki/fujisue/androidlab/ui/reorderablelist/ReorderableListScreen.kt`)

**Navigation and UI integration**

* Registered the new route `Route.ReorderableListScreen` in the navigation system and updated the navigation logic to include the new screen. (`app/src/main/java/com/example/kouki/fujisue/androidlab/ui/navigation/Route.kt`, `app/src/main/java/com/example/kouki/fujisue/androidlab/MainActivity.kt`) [[1]](diffhunk://#diff-ada237a14372f32d72cb2aba065d6f8d85e6ceb6d4b57cf305fe745443f1bfbcR130-R135) [[2]](diffhunk://#diff-dff871803277c35be49c32e44f7df3ad2076a75c47e2912da873630fc77d259aR36) [[3]](diffhunk://#diff-dff871803277c35be49c32e44f7df3ad2076a75c47e2912da873630fc77d259aR154-R156)
* Updated the main screen menu to include an entry for the reorderable list screen with a descriptive label. (`app/src/main/java/com/example/kouki/fujisue/androidlab/ui/main/MainScreen.kt`)