### PR TITLE
widgetを追加

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -62,6 +62,8 @@ dependencies {
     implementation(libs.androidx.ui.graphics)
     implementation(libs.androidx.constraintlayout.compose)
     implementation(libs.androidx.work.work.runtime)
+    implementation(libs.androidx.glance.appwidget)
+    implementation(libs.androidx.glance.material3)
 
     implementation(libs.ktor.client.core)
     implementation(libs.ktor.client.okhttp)

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -34,6 +34,19 @@
             android:exported="false"
             android:label="Second Activity"
             android:theme="@style/Theme.AndroidLab" />
+
+        <!-- Glance Widget Receiver -->
+        <receiver
+            android:name=".ui.glance.CounterWidgetReceiver"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.appwidget.action.APPWIDGET_UPDATE" />
+            </intent-filter>
+            <meta-data
+                android:name="android.appwidget.provider"
+                android:resource="@xml/counter_widget_info" />
+        </receiver>
+
     </application>
 
 </manifest>

--- a/app/src/main/java/com/example/kouki/fujisue/androidlab/ui/glance/CounterWidget.kt
+++ b/app/src/main/java/com/example/kouki/fujisue/androidlab/ui/glance/CounterWidget.kt
@@ -3,7 +3,6 @@ package com.example.kouki.fujisue.androidlab.ui.glance
 import android.content.Context
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.unit.dp
-import androidx.datastore.preferences.core.intPreferencesKey
 import androidx.glance.Button
 import androidx.glance.GlanceId
 import androidx.glance.GlanceModifier
@@ -27,11 +26,6 @@ import com.example.kouki.fujisue.androidlab.SecondActivity
  * GlanceウィジェットのUIを定義するクラス
  */
 class CounterWidget : GlanceAppWidget() {
-
-    companion object {
-        // カウンターの値を保存するためのPreferences Key
-        internal val countKey = intPreferencesKey("glance_counter_key")
-    }
 
     override suspend fun provideGlance(context: Context, id: GlanceId) {
         provideContent {

--- a/app/src/main/java/com/example/kouki/fujisue/androidlab/ui/glance/CounterWidget.kt
+++ b/app/src/main/java/com/example/kouki/fujisue/androidlab/ui/glance/CounterWidget.kt
@@ -1,21 +1,77 @@
 package com.example.kouki.fujisue.androidlab.ui.glance
 
 import android.content.Context
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.unit.dp
+import androidx.datastore.preferences.core.intPreferencesKey
+import androidx.glance.Button
 import androidx.glance.GlanceId
+import androidx.glance.GlanceModifier
+import androidx.glance.GlanceTheme
+import androidx.glance.action.actionStartActivity
 import androidx.glance.appwidget.GlanceAppWidget
 import androidx.glance.appwidget.provideContent
+import androidx.glance.background
+import androidx.glance.layout.Alignment
+import androidx.glance.layout.Column
+import androidx.glance.layout.Row
+import androidx.glance.layout.Spacer
+import androidx.glance.layout.fillMaxSize
+import androidx.glance.layout.padding
+import androidx.glance.layout.width
 import androidx.glance.text.Text
+import com.example.kouki.fujisue.androidlab.MainActivity
+import com.example.kouki.fujisue.androidlab.SecondActivity
 
 /**
  * GlanceウィジェットのUIを定義するクラス
  */
 class CounterWidget : GlanceAppWidget() {
-    override suspend fun provideGlance(
-        context: Context,
-        id: GlanceId
-    ) {
+
+    companion object {
+        // カウンターの値を保存するためのPreferences Key
+        internal val countKey = intPreferencesKey("glance_counter_key")
+    }
+
+    override suspend fun provideGlance(context: Context, id: GlanceId) {
         provideContent {
-            Text("Hello World")
+            // GlanceThemeでMaterial3のデザインを適用
+            GlanceTheme {
+                MyContent(
+                    context = context
+                )
+            }
+        }
+    }
+
+    @Composable
+    private fun MyContent(
+        context: Context
+    ) {
+        Column(
+            modifier = GlanceModifier
+                .fillMaxSize()
+                .background(color = GlanceTheme.colors.background.getColor(context)),
+            verticalAlignment = Alignment.Top,
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            Text(text = "Where to?", modifier = GlanceModifier.padding(12.dp))
+            Row(
+                horizontalAlignment =
+                    Alignment.CenterHorizontally
+            ) {
+                Button(
+                    text = "メイン",
+                    onClick = actionStartActivity<MainActivity>()
+                )
+                Spacer(
+                    modifier = GlanceModifier.width(16.dp)
+                )
+                Button(
+                    text = "サブ",
+                    onClick = actionStartActivity<SecondActivity>()
+                )
+            }
         }
     }
 }

--- a/app/src/main/java/com/example/kouki/fujisue/androidlab/ui/glance/CounterWidget.kt
+++ b/app/src/main/java/com/example/kouki/fujisue/androidlab/ui/glance/CounterWidget.kt
@@ -1,0 +1,21 @@
+package com.example.kouki.fujisue.androidlab.ui.glance
+
+import android.content.Context
+import androidx.glance.GlanceId
+import androidx.glance.appwidget.GlanceAppWidget
+import androidx.glance.appwidget.provideContent
+import androidx.glance.text.Text
+
+/**
+ * GlanceウィジェットのUIを定義するクラス
+ */
+class CounterWidget : GlanceAppWidget() {
+    override suspend fun provideGlance(
+        context: Context,
+        id: GlanceId
+    ) {
+        provideContent {
+            Text("Hello World")
+        }
+    }
+}

--- a/app/src/main/java/com/example/kouki/fujisue/androidlab/ui/glance/CounterWidgetReceiver.kt
+++ b/app/src/main/java/com/example/kouki/fujisue/androidlab/ui/glance/CounterWidgetReceiver.kt
@@ -1,0 +1,13 @@
+package com.example.kouki.fujisue.androidlab.ui.glance
+
+import androidx.glance.appwidget.GlanceAppWidget
+import androidx.glance.appwidget.GlanceAppWidgetReceiver
+
+/**
+ * ウィジェットをホストするためのAppWidgetReceiver
+ */
+class CounterWidgetReceiver : GlanceAppWidgetReceiver() {
+
+    // このレシーバーが扱うGlanceAppWidgetのインスタンスを返す
+    override val glanceAppWidget: GlanceAppWidget = CounterWidget()
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,3 +1,4 @@
 <resources>
     <string name="app_name">AndroidLab</string>
+    <string name="glance_widget_description">A simple counter widget.</string>
 </resources>

--- a/app/src/main/res/xml/counter_widget_info.xml
+++ b/app/src/main/res/xml/counter_widget_info.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<appwidget-provider xmlns:android="http://schemas.android.com/apk/res/android"
+    android:minWidth="180dp"
+    android:minHeight="40dp"
+    android:targetCellWidth="2"
+    android:targetCellHeight="1"
+    android:updatePeriodMillis="86400000"
+    android:initialLayout="@layout/glance_default_loading_layout"
+    android:description="@string/glance_widget_description"
+    android:previewLayout="@layout/glance_default_loading_layout"
+    android:resizeMode="horizontal|vertical"
+    android:widgetCategory="home_screen" />

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -16,6 +16,7 @@ constraintlayout = "1.1.1"
 room_version = "2.8.0"
 google_services = "21.3.0"
 work_version = "2.10.4"
+glance_version = "1.1.1"
 
 
 [libraries]
@@ -63,6 +64,10 @@ play-services-location = { group = "com.google.android.gms", name = "play-servic
 
 # WorkManager
 androidx-work-work-runtime = { group = "androidx.work", name = "work-runtime-ktx", version.ref = "work_version" }
+
+# glance
+androidx-glance-appwidget = { group = "androidx.glance", name = "glance-appwidget", version.ref = "glance_version" }
+androidx-glance-material3 = { group = "androidx.glance", name = "glance-material3", version.ref = "glance_version" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
This pull request adds a new Glance-based app widget to the project, allowing users to launch main and secondary activities directly from their home screen. The implementation includes all necessary code, resources, and configuration updates to support the widget.

**App Widget Implementation**

* Added `CounterWidget` class in `CounterWidget.kt` to define the Glance widget UI, featuring buttons to launch `MainActivity` and `SecondActivity`.
* Added `CounterWidgetReceiver` class in `CounterWidgetReceiver.kt` to host the widget via `GlanceAppWidgetReceiver`.

**Manifest and Resource Configuration**

* Updated `AndroidManifest.xml` to register `CounterWidgetReceiver` and provide widget metadata via `counter_widget_info.xml`.
* Added `counter_widget_info.xml` to configure widget size, update period, layout, and description.
* Added a string resource for the widget description in `strings.xml`.

**Dependency Management**

* Added Glance libraries (`glance-appwidget` and `glance-material3`) to `gradle/libs.versions.toml` and `build.gradle.kts` for widget support. [[1]](diffhunk://#diff-697f70cdd88ba88fe77eebda60c7e143f6ad1286bca75017421e93ad84fb87dfR19) [[2]](diffhunk://#diff-697f70cdd88ba88fe77eebda60c7e143f6ad1286bca75017421e93ad84fb87dfR68-R71) [[3]](diffhunk://#diff-8cff73265af19c059547b76aca8882cbaa3209291406f52df1dafbbc78e80c46R65-R66)