### PR TITLE
修正

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -22,7 +22,7 @@ android {
 
     buildTypes {
 
-        // デバックビルドの場合
+        // デバッグビルドの場合
         debug {
             isMinifyEnabled = false
             applicationIdSuffix = ".debug"

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -38,13 +38,16 @@ android {
             )
         }
     }
+
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_11
         targetCompatibility = JavaVersion.VERSION_11
     }
-    kotlinOptions {
-        jvmTarget = "11"
+
+    kotlin {
+        jvmToolchain(11)
     }
+
     buildFeatures {
         compose = true
     }

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -21,8 +21,17 @@ android {
     }
 
     buildTypes {
-        release {
+
+        // デバックビルドの場合
+        debug {
             isMinifyEnabled = false
+            applicationIdSuffix = ".debug"
+            versionNameSuffix = "-debug"
+        }
+
+        // リリースビルドの場合
+        release {
+            isMinifyEnabled = true
             proguardFiles(
                 getDefaultProguardFile("proguard-android-optimize.txt"),
                 "proguard-rules.pro"


### PR DESCRIPTION
This pull request updates the build configuration in `app/build.gradle.kts` to better distinguish between debug and release builds and modernizes Java/Kotlin settings. The most important changes are the addition of a dedicated debug build type and the migration to the recommended Kotlin JVM toolchain configuration.

**Build type improvements:**

* Added a `debug` build type with `applicationIdSuffix` and `versionNameSuffix` to clearly identify debug builds. Minification is disabled for debug builds.
* Updated the `release` build type to enable code minification and clarified its configuration.

**Kotlin/Java configuration modernization:**

* Replaced the deprecated `kotlinOptions.jvmTarget` setting with the recommended `kotlin.jvmToolchain(11)` for JVM compatibility.