### PR TITLE
Statescreenを追加

### DIFF
--- a/app/src/main/java/com/example/kouki/fujisue/androidlab/MainActivity.kt
+++ b/app/src/main/java/com/example/kouki/fujisue/androidlab/MainActivity.kt
@@ -36,6 +36,7 @@ import com.example.kouki.fujisue.androidlab.ui.permission.PermissionsScreen
 import com.example.kouki.fujisue.androidlab.ui.reorderablelist.ReorderableListScreen
 import com.example.kouki.fujisue.androidlab.ui.savedinstancestate.SavedInstanceStateScreen
 import com.example.kouki.fujisue.androidlab.ui.sideeffect.SideEffectScreen
+import com.example.kouki.fujisue.androidlab.ui.state.StateScreen
 import com.example.kouki.fujisue.androidlab.ui.storage.StorageScreen
 import com.example.kouki.fujisue.androidlab.ui.text.TextScreen
 import com.example.kouki.fujisue.androidlab.ui.theme.AndroidLabTheme
@@ -157,6 +158,9 @@ fun AppContent() {
             }
             composable<Route.WebViewScreen> {
                 WebViewScreen()
+            }
+            composable<Route.StateScreen> {
+                StateScreen()
             }
         }
     }

--- a/app/src/main/java/com/example/kouki/fujisue/androidlab/ui/main/MainScreen.kt
+++ b/app/src/main/java/com/example/kouki/fujisue/androidlab/ui/main/MainScreen.kt
@@ -41,7 +41,8 @@ fun MainScreen(navController: NavController) {
                 Route.LayoutsScreen to "レイアウト方法を学ぶ画面",
                 Route.ListScreen to "リスト表示を試す画面",
                 Route.DialogScreen to "ダイアログ表示を試す画面",
-                Route.OtherScreen to "その他のUIコンポーネントを試す画面"
+                Route.OtherScreen to "その他のUIコンポーネントを試す画面",
+                Route.StateScreen to "Composeの状態について学ぶ画面"
             )
         ),
         ScreenSection(

--- a/app/src/main/java/com/example/kouki/fujisue/androidlab/ui/navigation/Route.kt
+++ b/app/src/main/java/com/example/kouki/fujisue/androidlab/ui/navigation/Route.kt
@@ -139,4 +139,10 @@ object Route {
      */
     @Serializable
     data object WebViewScreen
+
+    /**
+     * Composeの状態について学ぶ画面
+     */
+    @Serializable
+    data object StateScreen
 }

--- a/app/src/main/java/com/example/kouki/fujisue/androidlab/ui/state/StateScreen.kt
+++ b/app/src/main/java/com/example/kouki/fujisue/androidlab/ui/state/StateScreen.kt
@@ -1,0 +1,81 @@
+package com.example.kouki.fujisue.androidlab.ui.state
+
+import android.util.Log
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Button
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+
+private const val TAG = "StateScreen"
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun StateScreen() {
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("Composeの状態について学ぶ") },
+                colors = TopAppBarDefaults.topAppBarColors(
+                    containerColor = MaterialTheme.colorScheme.primaryContainer,
+                    titleContentColor = MaterialTheme.colorScheme.primary,
+                )
+            )
+        }
+    ) { paddingValues ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(paddingValues)
+                .padding(16.dp)
+                .verticalScroll(rememberScrollState())
+        ) {
+            StateAndNoStateExample()
+        }
+    }
+}
+
+@Composable
+private fun StateAndNoStateExample() {
+    Log.d(TAG, "StateAndNoStateExample recomposed")
+
+    // Stateを持たない変数
+    var countWithoutState = 0
+
+    // Stateを持つ変数
+    var countWithState by remember { mutableIntStateOf(0) }
+
+    Text("Stateの有無による再描画の違い")
+
+    // Stateを持たないカウンター
+    Button(onClick = {
+        countWithoutState++
+        Log.d(TAG, "Button 1 clicked, countWithoutState: $countWithoutState")
+    }) {
+        Log.d(TAG, "Button 1 recomposed")
+        Text("Counter without state: $countWithoutState")
+    }
+
+    // Stateを持つカウンター
+    Button(onClick = {
+        countWithState++
+        Log.d(TAG, "Button 2 clicked, countWithState: $countWithState")
+    }) {
+        Log.d(TAG, "Button 2 recomposed")
+        Text("Counter with state: $countWithState")
+    }
+}

--- a/app/src/main/java/com/example/kouki/fujisue/androidlab/ui/state/StateScreen.kt
+++ b/app/src/main/java/com/example/kouki/fujisue/androidlab/ui/state/StateScreen.kt
@@ -2,7 +2,9 @@ package com.example.kouki.fujisue.androidlab.ui.state
 
 import android.util.Log
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
@@ -45,6 +47,8 @@ fun StateScreen() {
                 .verticalScroll(rememberScrollState())
         ) {
             StateAndNoStateExample()
+            Spacer(modifier = Modifier.height(32.dp))
+            StableAndUnstableExample()
         }
     }
 }
@@ -78,4 +82,43 @@ private fun StateAndNoStateExample() {
         Log.d(TAG, "Button 2 recomposed")
         Text("Counter with state: $countWithState")
     }
+}
+
+// 不安定なデータクラス
+private class UnstableData(var name: String)
+
+// 安定なデータクラス
+private data class StableData(val name: String)
+
+@Composable
+private fun StableAndUnstableExample() {
+    Log.d(TAG, "StableAndUnstableExample recomposed")
+
+    val unstableData = remember { UnstableData("initial") }
+    val stableData = remember { StableData("initial") }
+
+    var recompositionTrigger by remember { mutableIntStateOf(0) }
+
+    Text("安定性の違いによる再描画の違い")
+    Button(onClick = { recompositionTrigger++ }) {
+        Text("Trigger Recomposition")
+    }
+
+    // このTextで状態を読み取ることで、再コンポーズがトリガーされることを保証します。
+    Text(text = "Trigger count: $recompositionTrigger")
+
+    UnstableComposable(data = unstableData)
+    StableComposable(data = stableData)
+}
+
+@Composable
+private fun UnstableComposable(data: UnstableData) {
+    Log.d(TAG, "UnstableComposable recomposed with data: ${data.name}")
+    Text(text = "Unstable: ${data.name}")
+}
+
+@Composable
+private fun StableComposable(data: StableData) {
+    Log.d(TAG, "StableComposable recomposed with data: ${data.name}")
+    Text(text = "Stable: ${data.name}")
 }


### PR DESCRIPTION
This pull request adds a new screen to the app that teaches about state management in Jetpack Compose. It introduces the `StateScreen`, updates navigation to include it, and ensures it's accessible from the main menu. The new screen demonstrates differences between stateful and stateless variables, as well as stable and unstable data classes in Compose recompositions.

**New Feature: State Learning Screen**
* Added a new composable screen `StateScreen` in `StateScreen.kt`, which provides examples and explanations of state handling and data stability in Jetpack Compose.

**Navigation Updates**
* Registered `Route.StateScreen` in the navigation routes (`Route.kt`) to enable navigation to the new state screen.
* Updated `AppContent()` in `MainActivity.kt` to include navigation logic for `StateScreen`.
* Imported `StateScreen` in `MainActivity.kt` to support the new route.

**Main Menu Update**
* Added an entry for "Composeの状態について学ぶ画面" (Learn about state in Compose) to the main screen menu, making the new screen discoverable by users.